### PR TITLE
Update versions of google dependencies in build.gradle cargo module file

### DIFF
--- a/cargo/build.gradle
+++ b/cargo/build.gradle
@@ -22,7 +22,8 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.google.android.gms:play-services-analytics:8.1.0'
+    compile 'com.google.android.gms:play-services-analytics:8.4.0'
+    compile 'com.google.android.gms:play-services:8.4.0'
 }
 
 ext{

--- a/cargo/src/main/java/com/fiftyfive/cargo/Cargo.java
+++ b/cargo/src/main/java/com/fiftyfive/cargo/Cargo.java
@@ -2,7 +2,6 @@ package com.fiftyfive.cargo;
 
 import android.app.Application;
 import android.util.Log;
-
 import com.google.android.gms.tagmanager.Container;
 
 /**


### PR DESCRIPTION
Adding a google dependency ('com.google.android.gms:play-services:8.4.0') in cargo build.gradle helped the build to be done succesfully #23