### PR TITLE
correction of String retrieval for the site id for AT handler

### DIFF
--- a/cargo-handlers/atinternet/src/main/java/com/fiftyfive/cargo/handlers/ATInternetHandler.java
+++ b/cargo-handlers/atinternet/src/main/java/com/fiftyfive/cargo/handlers/ATInternetHandler.java
@@ -112,12 +112,14 @@ public class ATInternetHandler extends AbstractTagHandler {
         final String LOG = "log";
         final String LOG_SSL = "logSSL";
 
-        final String siteId = getString(params, SITE);
+        Double appIdDouble = getDouble(params, SITE, 0);
+        Long appIdLong = appIdDouble.longValue();
+        final String siteId = Long.toString(appIdLong);
         final String log = getString(params, LOG);
         final String logSSL = getString(params, LOG_SSL);
         enableDebug = getBoolean(params, com.fiftyfive.cargo.models.Tracker.ENABLE_DEBUG, false);
 
-        if (siteId != null && log != null && logSSL != null) {
+        if (appIdLong != 0 && siteId != null && log != null && logSSL != null) {
             HashMap config = new HashMap<>();
             config.put(SITE, siteId);
             config.put(LOG, log);

--- a/cargo-handlers/atinternet/src/test/java/com/fiftyfive/cargo/handlers/ATInternetHandlerTest.java
+++ b/cargo-handlers/atinternet/src/test/java/com/fiftyfive/cargo/handlers/ATInternetHandlerTest.java
@@ -93,7 +93,7 @@ public class ATInternetHandlerTest extends TestCase {
     public void testInit(){
 
         HashMap<String, Object> map = new HashMap<>();
-        map.put("site", "fifty-five");
+        map.put("site", "123456.0");
         map.put("log", "logc1");
         map.put("logSSL", "logSecure2");
 


### PR DESCRIPTION
Corrected an error while retrieving the site id for AT. Used to retrieve a Double value, eg _xxxxx.0_